### PR TITLE
Sync dockerimage tool fields with supported

### DIFF
--- a/Devfile.yaml
+++ b/Devfile.yaml
@@ -8,16 +8,24 @@ projects:
       location: 'git@github.com:spring-projects/spring-petclinic.git'
 tools:
   - name: mvn-stack
-    type: dockerImage
+    type: dockerimage
     image: maven:3.5.4-jdk-8
     entryPoint: sleep infinity
-    persistentVolumes:
+    volumes:
       - name: maven-repo
         containerPath: /root/.m2
-    services:
+    endpoints:
       - name: spring-boot
         port: 8080
-    mountProjectsSources: true
+        attributes:
+          path: /api
+          protocol: http
+          public: true
+    env:
+      - name: TERM
+        value: xterm
+    mountSources: true
+    memoryLimit: 500M
   - name: mysql
     type: kubernetes
     local: petclinic.yaml


### PR DESCRIPTION
Sync dockerimage tool fields with supported:
- changed `dockerImage` tool type to `dockerimage`;
- renamed `persistentVolumes` to `volumes`;
- renamed `services` to `endpoints`;
- added attributes to `endpoint`;
- added `env` field;
- added `mountSources`;
- added `memoryLimit`;