### PR TITLE
Fix example of specifying entrypoint for dockerimage tool

### DIFF
--- a/Devfile.yaml
+++ b/Devfile.yaml
@@ -10,7 +10,8 @@ tools:
   - name: mvn-stack
     type: dockerimage
     image: maven:3.5.4-jdk-8
-    entryPoint: sleep infinity
+    command: ['/bin/sh', '-c']
+    args: ['tail -f /dev/null']
     volumes:
       - name: maven-repo
         containerPath: /root/.m2


### PR DESCRIPTION
There is agreement about using `command` and `args` fields to specify docker image entrypoint https://github.com/eclipse/che/issues/12668
This PR sync dockerimage tool format according to it.