### PR TITLE
Use https link instead of ssh link in the sample

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ projects:
   - name: petclinic
     source:
       type: git
-      location: 'git@github.com:spring-projects/spring-petclinic.git'
+      location: 'https://github.com/spring-projects/spring-petclinic.git'
 tools:
   - name: theia-editor
     type: cheEditor


### PR DESCRIPTION
Use https link instead of ssh link in the sample. By default CHE workspace doesn't has ssh keys.