### PR TITLE
Adding stop command to the vaadin 'getting-started' devfile

### DIFF
--- a/getting-started/vaadin-addressbook/devfile.yaml
+++ b/getting-started/vaadin-addressbook/devfile.yaml
@@ -47,3 +47,8 @@ commands:
       - type: exec
         component: maven
         command: "mvn -f ${CHE_PROJECTS_ROOT}/addressbook jetty:run"
+  - name: stop
+    actions:
+      - type: exec
+        component: maven
+        command: "echo 'Stopping the application...' && kill $(pidof java) && echo 'The application has been successfully stopped'"


### PR DESCRIPTION
Until this theia issue is resolved it looks like we need to specify stop commands explicitly in the devfiles https://github.com/eclipse/che/issues/13737#issuecomment-493868402