### PR TITLE
Adding go 'getting-started' devfile

### DIFF
--- a/getting-started/go/README.MD
+++ b/getting-started/go/README.MD
@@ -1,0 +1,1 @@
+[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/go/devfile.yaml)

--- a/getting-started/go/devfile.yaml
+++ b/getting-started/go/devfile.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: 1.0.0
+metadata:
+  name: golang
+attributes:
+  persistVolumes: 'false'
+projects:
+-
+  name: example
+  source:
+    type: git
+    location: https://github.com/golang/example.git
+  clonePath: src/github.com/golang/example/
+components:
+-
+  type: chePlugin
+  id: ms-vscode/go/latest
+  alias: go-plugin
+  memoryLimit: 512Mi
+-
+  type: dockerimage
+  # this version is used in the plugin
+  image: quay.io/eclipse/che-golang-1.10:nightly
+  alias: go-cli
+  env:
+    - name: GOPATH
+      # replicate the GOPATH from the plugin
+      value: /go:$(CHE_PROJECTS_ROOT)
+    - name: GOCACHE
+      # replicate the GOCACHE from the plugin, even though the cache is not shared
+      # between the two
+      value: /tmp/.cache
+  endpoints:
+    - name: '8080/tcp'
+      port: 8080
+  memoryLimit: 512Mi
+  mountSources: true
+commands:
+-
+  name: run outyet
+  actions:
+  - type: exec
+    component: go-cli
+    command: go get -d && go run main.go
+    workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
+-
+  name: stop outyet
+  actions:
+  - type: exec
+    component: go-cli
+    command: kill $(pidof go)
+-
+  name: test outyet
+  actions:
+  - type: exec
+    component: go-cli
+    command: go test
+    workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
+-
+  name: Debug current file
+  actions:
+  - type: vscode-launch
+    referenceContent: |
+      {
+        "version": "0.2.0",
+        "configurations": [
+          {
+            "name": "Debug current file",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+          },
+        ]
+      }


### PR DESCRIPTION
For Che 7 GA we are going to replace C++ with Go on the getting-started page - https://github.com/redhat-developer/rh-che/issues/1451
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>