### PR TITLE
Adding Quarkus 'getting-started' devfile

### DIFF
--- a/getting-started/angular/README.MD
+++ b/getting-started/angular/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/angular/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/angular/devfile.yaml)

--- a/getting-started/go/README.MD
+++ b/getting-started/go/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/go/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/go/devfile.yaml)

--- a/getting-started/java-gradle/README.MD
+++ b/getting-started/java-gradle/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-gradle/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-gradle/devfile.yaml)

--- a/getting-started/java-maven/README.MD
+++ b/getting-started/java-maven/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-maven/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-maven/devfile.yaml)

--- a/getting-started/nodejs/README.MD
+++ b/getting-started/nodejs/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/nodejs/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/nodejs/devfile.yaml)

--- a/getting-started/php/README.MD
+++ b/getting-started/php/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/php/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/php/devfile.yaml)

--- a/getting-started/quarkus/README.md
+++ b/getting-started/quarkus/README.md
@@ -1,0 +1,1 @@
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/quarkus/devfile.yaml)

--- a/getting-started/quarkus/devfile.yaml
+++ b/getting-started/quarkus/devfile.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: quarkus-
+attributes:
+  persistVolumes: 'false'
+projects:
+  -
+    name: quarkus-quickstarts
+    source:
+      type: git
+      location: "https://github.com/quarkusio/quarkus-quickstarts.git"
+      sparseCheckoutDir: getting-started
+components:
+  -
+    type: chePlugin
+    id: redhat/quarkus-java11/latest
+  -
+    type: dockerimage
+    alias: centos-quarkus-maven
+    image: quay.io/eclipse/che-quarkus:nightly
+    env:
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+          -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
+          -Duser.home=/home/user"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)  
+    memoryLimit: 4927M
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/user/.m2
+    endpoints:
+      - name: 'hello-greeting-endpoint'
+        port: 8080
+        attributes:
+          path: /hello/greeting/che-user
+
+  - type: dockerimage
+    alias: ubi-minimal
+    image: 'registry.access.redhat.com/ubi8/ubi-minimal'
+    memoryLimit: 32M
+    mountSources: true
+    endpoints:
+      - name: 'hello-greeting-endpoint'
+        port: 8080
+        attributes:
+          path: /hello/greeting/che-user
+    command: ['tail']
+    args: ['-f', '/dev/null']
+
+commands:
+  -
+    name: Package
+    actions:
+      -
+        type: exec
+        component: centos-quarkus-maven
+        command: "./mvnw package"
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+  -
+    name: Start Development mode (Hot reload + debug)
+    actions:
+      -
+        type: exec
+        component: centos-quarkus-maven
+        command: "./mvnw compile quarkus:dev"
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+  -
+    name: Package Native
+    actions:
+      -
+        type: exec
+        component: centos-quarkus-maven
+        command: "./mvnw package -Dnative -Dmaven.test.skip"
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+
+  -
+    name: Start Native
+    actions:
+      -
+        type: exec
+        component: ubi-minimal
+        command: ./getting-started-1.0-SNAPSHOT-runner
+        workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started/target
+  -
+    name: Attach remote debugger
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "request": "attach",
+              "name": "Attach to Remote Quarkus App",
+              "hostName": "localhost",
+              "port": 5005
+            }
+          ]
+        }

--- a/getting-started/spring-boot/README.md
+++ b/getting-started/spring-boot/README.md
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-boot/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-boot/devfile.yaml)

--- a/getting-started/spring-petclinic/README.MD
+++ b/getting-started/spring-petclinic/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-petclinic/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-petclinic/devfile.yaml)

--- a/getting-started/spring-rest-guide/README.MD
+++ b/getting-started/spring-rest-guide/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-rest-guide/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-rest-guide/devfile.yaml)

--- a/getting-started/thorntail/README.MD
+++ b/getting-started/thorntail/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/thorntail/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/thorntail/devfile.yaml)

--- a/getting-started/vaadin-addressbook/README.MD
+++ b/getting-started/vaadin-addressbook/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vaadin-addressbook/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vaadin-addressbook/devfile.yaml)

--- a/getting-started/vertx/README.MD
+++ b/getting-started/vertx/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.prod-preview.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vertx/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vertx/devfile.yaml)


### PR DESCRIPTION
Related issue - https://github.com/eclipse/che/issues/17961
Try it on Hosted Che:

[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/ibuziuk/devfile/che-17961/getting-started/quarkus/devfile.yaml)

![image](https://user-images.githubusercontent.com/1461122/96581107-9f9cf900-12d9-11eb-9aed-1a1199d365f3.png)
