### PR TITLE
Fix Route API version

### DIFF
--- a/samples/web-nodejs-with-db-sample/mongo-db.yaml
+++ b/samples/web-nodejs-with-db-sample/mongo-db.yaml
@@ -10,6 +10,9 @@ items:
       name: mongo
     name: mongo-controller
   spec:
+    selector:
+      matchLabels:
+        name: mongo
     template:
       metadata:
         labels:
@@ -36,7 +39,6 @@ items:
     name: mongo
     labels:
       name: mongo
-    name: mongo
   spec:
     ports:
       - port: 27017

--- a/samples/web-nodejs-with-db-sample/nodejs-app.yaml
+++ b/samples/web-nodejs-with-db-sample/nodejs-app.yaml
@@ -64,7 +64,7 @@ objects:
     selector:
       app: nodejs
 -
-  apiVersion: v1
+  apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     name: che

--- a/samples/web-nodejs-with-db-sample/nodejs-app.yaml
+++ b/samples/web-nodejs-with-db-sample/nodejs-app.yaml
@@ -14,7 +14,8 @@ objects:
   spec:
     replicas: 1
     selector:
-      name: web
+      matchLabels:
+        app: nodejs
     template:
       metadata:
         labels:


### PR DESCRIPTION
### What does this PR do?
Depending on the tool and its version, v1 for Route may not be recognized, we faced it on the devworkspace controller side https://github.com/devfile/devworkspace-operator/pull/187#discussion_r515943097

So, this PR replace v1 with full Route API version which is `route.openshift.io/v1`.

Also, it fixes deployments selector to avoid:
```
The Deployment "web" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string(nil), MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: empty selector is invalid for deployment
```
error when applying these resources.

### Which issues does this PR references?
It should fix https://github.com/redhat-developer/devfile/pull/65

Probably it does not fully fix but improve the situation for https://issues.redhat.com/browse/RHDEVDOCS-2154
