### PR TITLE
use express-3 and fix permission issue with HOME workaround

### DIFF
--- a/samples/web-nodejs-with-db-sample/devfile.yaml
+++ b/samples/web-nodejs-with-db-sample/devfile.yaml
@@ -5,8 +5,8 @@ projects:
   - name: nodejs-mongo-app
     source:
       type: git
-      location: 'https://github.com/sunix/NodeJS-Sample-App.git'
-      branch: express-3
+      location: 'https://github.com/ijason/NodeJS-Sample-App.git'
+      commitId: 187d46d83b705d723e8fff67ed2197a1b8c36
 components:
   - type: kubernetes
     reference: mongo-db.yaml

--- a/samples/web-nodejs-with-db-sample/devfile.yaml
+++ b/samples/web-nodejs-with-db-sample/devfile.yaml
@@ -18,4 +18,4 @@ commands:
     actions:
       - type: exec
         component: nodejs-app
-        command: export HOME=${CHE_PROJECTS_ROOT}; cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && sed -i -- ''s/localhost/mongo/g'' app.js && node app.js
+        command: cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && sed -i -- ''s/localhost/mongo/g'' app.js && node app.js

--- a/samples/web-nodejs-with-db-sample/devfile.yaml
+++ b/samples/web-nodejs-with-db-sample/devfile.yaml
@@ -6,7 +6,7 @@ projects:
     source:
       type: git
       location: 'https://github.com/ijason/NodeJS-Sample-App.git'
-      commitId: 187d46d83b705d723e8fff67ed2197a1b8c36
+      commitId: 187d468
 components:
   - type: kubernetes
     reference: mongo-db.yaml

--- a/samples/web-nodejs-with-db-sample/devfile.yaml
+++ b/samples/web-nodejs-with-db-sample/devfile.yaml
@@ -5,7 +5,8 @@ projects:
   - name: nodejs-mongo-app
     source:
       type: git
-      location: 'https://github.com/ijason/NodeJS-Sample-App.git'
+      location: 'https://github.com/sunix/NodeJS-Sample-App.git'
+      branch: express-3
 components:
   - type: kubernetes
     reference: mongo-db.yaml
@@ -17,4 +18,4 @@ commands:
     actions:
       - type: exec
         component: nodejs-app
-        command: cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && sed -i -- ''s/localhost/mongo/g'' app.js && node app.js
+        command: export HOME=${CHE_PROJECTS_ROOT}; cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && sed -i -- ''s/localhost/mongo/g'' app.js && node app.js

--- a/samples/web-nodejs-with-db-sample/devfile.yaml
+++ b/samples/web-nodejs-with-db-sample/devfile.yaml
@@ -6,7 +6,7 @@ projects:
     source:
       type: git
       location: 'https://github.com/ijason/NodeJS-Sample-App.git'
-      commitId: 187d468
+      commitId: 187d468 # refers to the last commitId the project compiles (with express3)
 components:
   - type: kubernetes
     reference: mongo-db.yaml

--- a/samples/web-nodejs-with-db-sample/nodejs-app.yaml
+++ b/samples/web-nodejs-with-db-sample/nodejs-app.yaml
@@ -37,6 +37,9 @@ objects:
          - name: projects
            persistentVolumeClaim:
              claimName: projects
+        env:
+         - name: HOME
+           value: '/projects'
 -
   apiVersion: v1
   kind: PersistentVolumeClaim


### PR DESCRIPTION
Fix https://github.com/eclipse/che/issues/15649,
- Setting the commitid to before the changes as migration to express 4 involves too many changes.
- Setting HOME env variable to /projects so we can write to the folder.
- Tested with Eclipse Che + Openshift 4.6