### PR TITLE
Updating devfile/factory URLs to workspaces.openshift.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devfile v1
 
-[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://che.openshift.io/f?url=https://github.com/redhat-developer/devfile)
+[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://workspaces.openshift.com/f?url=https://github.com/redhat-developer/devfile)
 
 This repository contains the specs, docs and examples of the Devfile v1.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -340,7 +340,7 @@ attributes:
 
 ### Live working examples
 
-  - [NodeJS simple "Hello World" example](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-nodejs-sample/devfile.yaml)
-  - [NodeJS Application with Mongo DB example](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-nodejs-with-db-sample/devfile.yaml)
-  - [Java Spring-Petclinic example](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-java-spring-petclinic/devfile.yaml)
-  - [Theia frontend plugin example](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/theia-hello-world-frontend-plugin/devfile.yaml)
+  - [NodeJS simple "Hello World" example](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-nodejs-sample/devfile.yaml)
+  - [NodeJS Application with Mongo DB example](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-nodejs-with-db-sample/devfile.yaml)
+  - [Java Spring-Petclinic example](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-java-spring-petclinic/devfile.yaml)
+  - [Theia frontend plugin example](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/theia-hello-world-frontend-plugin/devfile.yaml)

--- a/getting-started/angular/README.MD
+++ b/getting-started/angular/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/angular/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/angular/devfile.yaml)

--- a/getting-started/go/README.MD
+++ b/getting-started/go/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/go/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/go/devfile.yaml)

--- a/getting-started/java-gradle/README.MD
+++ b/getting-started/java-gradle/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-gradle/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-gradle/devfile.yaml)

--- a/getting-started/java-maven/README.MD
+++ b/getting-started/java-maven/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-maven/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/java-maven/devfile.yaml)

--- a/getting-started/nodejs/README.MD
+++ b/getting-started/nodejs/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/nodejs/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/nodejs/devfile.yaml)

--- a/getting-started/php/README.MD
+++ b/getting-started/php/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/php/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/php/devfile.yaml)

--- a/getting-started/quarkus/README.md
+++ b/getting-started/quarkus/README.md
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/quarkus/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/quarkus/devfile.yaml)

--- a/getting-started/spring-boot/README.md
+++ b/getting-started/spring-boot/README.md
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-boot/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-boot/devfile.yaml)

--- a/getting-started/spring-petclinic/README.MD
+++ b/getting-started/spring-petclinic/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-petclinic/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-petclinic/devfile.yaml)

--- a/getting-started/spring-rest-guide/README.MD
+++ b/getting-started/spring-rest-guide/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-rest-guide/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/spring-rest-guide/devfile.yaml)

--- a/getting-started/thorntail/README.MD
+++ b/getting-started/thorntail/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/thorntail/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/thorntail/devfile.yaml)

--- a/getting-started/vaadin-addressbook/README.MD
+++ b/getting-started/vaadin-addressbook/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vaadin-addressbook/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vaadin-addressbook/devfile.yaml)

--- a/getting-started/vertx/README.MD
+++ b/getting-started/vertx/README.MD
@@ -1,1 +1,1 @@
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vertx/devfile.yaml)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/getting-started/vertx/devfile.yaml)


### PR DESCRIPTION
March 1st, is the official EOL day for Hosted Che.
Need to migrate the 'getting-started' devfile to `workspaces.openshift.com`

Getting started defiles are used on the official website - https://www.eclipse.org/che/getting-started/cloud/

Example: [![Contribute](https://www.eclipse.org/che/factory-contribute.svg)](https://workspaces.openshift.com/f?url=https://github.com/redhat-developer/devfile)